### PR TITLE
Make IsInDescendingOrder working like IsInAscendingOrder

### DIFF
--- a/code/src/NFluent/Checks/EnumerableCheckExtensions.cs
+++ b/code/src/NFluent/Checks/EnumerableCheckExtensions.cs
@@ -1025,10 +1025,10 @@ namespace NFluent
                 FailIfNull().
                 Analyze((sut, test) =>
                 {
-                    IComparable previous = null;
+                    object previous = null;
                     var index = 0;
                     var first = true;
-                    foreach (IComparable current in sut)
+                    foreach (var current in sut)
                     {
                         if (!first)
                         {


### PR DESCRIPTION
No need to inherit from IComparable